### PR TITLE
Update Ariel OS

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -112,6 +112,7 @@ dependencies = [
  "embassy-stm32",
  "embassy-sync 0.7.2",
  "embassy-time",
+ "embassy-time-queue-utils",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-io 0.6.1",

--- a/examples/laze-project.yml
+++ b/examples/laze-project.yml
@@ -2,7 +2,7 @@ imports:
   - git:
       url: https://github.com/chrysn-pull-requests/ariel-os
       #commit: for-hophop
-      commit: f3c81479311db4593c9664f68e08a14ace9c70f8
+      commit: 4416d794b3eeeefc1297862c23a7898f672e46d0
     dldir: ariel-os
 
 apps:


### PR DESCRIPTION
With https://github.com/ariel-os/ariel-os/pull/1398 merged, this now pulls in fewer branches, is free of a bunch of development artifacts (diverging branches between Kaspar and mine, removed fixups), and a better base to start updating the DECT PHY API.