### PR TITLE
Add a Glossary

### DIFF
--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright Julian Dickert <julian@systemscape.de>
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+
 Most common abbreviations used in the context of DECT-2020/NR+ according to ETSI TS 103 636-1
 
 - **ARQ**: Automatic Repeat reQuest
@@ -17,6 +22,7 @@ Most common abbreviations used in the context of DECT-2020/NR+ according to ETSI
 - **FDMA**: [Frequency Division Multiple Access](https://en.wikipedia.org/wiki/Frequency-division_multiple_access)
 - **FEC**: [Forward Error Correction](https://en.wikipedia.org/wiki/Error_correction_code)
 - **FFT**: Fast Fourier Transform
+- **FT**: Fixed Termination point
 - **GI**: Guard Interval
 - **LBT**: Listen Before Talk
 - **MAC**: Medium Access Control


### PR DESCRIPTION
While reading through the standard, I realized that there are quite a few abbreviations used. Some are very common in communications, but some seem very new.

This PR adds a glossary file to the docs that lists a selection of abbreviations found in the specification.
I have added most of the very new/special ones (that seem very particular to NR or even DECT-2020) and a few commonly used ones that might be interesting for people less familiar with (wireless) communications.