### PR TITLE
Use newtypes for channel, network and RD identifiers

### DIFF
--- a/examples/src/bin/ping.rs
+++ b/examples/src/bin/ping.rs
@@ -12,6 +12,8 @@ use ariel_os_boards::pins;
 use ts_103_636_numbers as numbers;
 use ts_103_636_utils as utils;
 
+use utils::identifiers::{AbsoluteChannel, NetworkId32};
+
 #[ariel_os::task(autostart, peripherals)]
 async fn main(peripherals: pins::ButtonPeripherals) {
     let mut dect = hophop::nrfxlib_phy::DectPhy::init_after_modem_init(())
@@ -33,7 +35,7 @@ async fn main(peripherals: pins::ButtonPeripherals) {
         // moment we can just leave it at that.
         if button0.is_high() {
             let received = dect
-                .rx(1665, 0)
+                .rx(const { AbsoluteChannel::new(1665).unwrap() }, None)
                 .await
                 .expect("Receive operation failed as a whole");
 
@@ -138,9 +140,15 @@ async fn main(peripherals: pins::ButtonPeripherals) {
                 .unwrap();
             }
 
-            dect.tx(transmit_time, 1665, 0x12345678, &pcc, &pdc_buf)
-                .await
-                .unwrap();
+            dect.tx(
+                transmit_time,
+                const { AbsoluteChannel::new(1665).unwrap() },
+                const { NetworkId32::new(0x12345678).unwrap() },
+                &pcc,
+                &pdc_buf,
+            )
+            .await
+            .unwrap();
 
             info!("Sent {} bytes PDC data", pdc_buf.len());
         }

--- a/examples/src/bin/rssi.rs
+++ b/examples/src/bin/rssi.rs
@@ -6,6 +6,8 @@
 use ariel_os::debug::{ExitCode, exit};
 use ariel_os::log::{error, info, warn};
 
+use ts_103_636_utils::identifiers::{AbsoluteChannel, NetworkId32};
+
 #[ariel_os::task(autostart)]
 async fn main() {
     let mut dect = hophop::nrfxlib_phy::DectPhy::init_after_modem_init(())
@@ -16,14 +18,26 @@ async fn main() {
         info!("DECT time is {:?}", dect.time_get().await);
 
         info!("Scanning band 1");
-        let scans = &[
-            1657, 1659, 1661, 1663, 1665, 1667, 1669, 1671, 1673, 1675, 1677,
-        ];
+        let scans = &const {
+            [
+                AbsoluteChannel::new(1657).unwrap(),
+                AbsoluteChannel::new(1659).unwrap(),
+                AbsoluteChannel::new(1661).unwrap(),
+                AbsoluteChannel::new(1663).unwrap(),
+                AbsoluteChannel::new(1665).unwrap(),
+                AbsoluteChannel::new(1667).unwrap(),
+                AbsoluteChannel::new(1669).unwrap(),
+                AbsoluteChannel::new(1671).unwrap(),
+                AbsoluteChannel::new(1673).unwrap(),
+                AbsoluteChannel::new(1675).unwrap(),
+                AbsoluteChannel::new(1677).unwrap(),
+            ]
+        };
         let mut scan_iterator = scans.iter();
         if let Err(e) = dect
             .rssi_bulk(
                 scans,
-                0x87654321,
+                const { NetworkId32::new(0x87654321).unwrap() },
                 async |result| {
                     let channel = scan_iterator.next().unwrap();
                     let Some(result) = result else {

--- a/examples/src/bin/rx.rs
+++ b/examples/src/bin/rx.rs
@@ -11,6 +11,7 @@ use ariel_os::log::{Hex, info, warn};
 
 use ts_103_636_numbers as numbers;
 use ts_103_636_utils as utils;
+use utils::identifiers::{AbsoluteChannel, NetworkId32};
 
 fn log_header(header: &[u8]) {
     // Following ETSI TS 103 636-4 V2.1.1 Section 6.2
@@ -69,7 +70,10 @@ async fn main() {
 
     for _ in 0..300 {
         if let Some(received) = dect
-            .rx(1665, 0x87654321)
+            .rx(
+                const { AbsoluteChannel::new(1665).unwrap() },
+                const { NetworkId32::new(0x87654321) },
+            )
             .await
             .expect("Receive operation failed as a whole")
         {

--- a/examples/src/bin/tx.rs
+++ b/examples/src/bin/tx.rs
@@ -11,6 +11,8 @@ use ariel_os::time::Timer;
 
 use ariel_os_boards::pins;
 
+use ts_103_636_utils::identifiers::{AbsoluteChannel, NetworkId32};
+
 #[ariel_os::task(autostart, peripherals)]
 async fn blinky(peripherals: pins::ButtonPeripherals) {
     let mut dect = hophop::nrfxlib_phy::DectPhy::init_after_modem_init(())
@@ -34,9 +36,8 @@ async fn blinky(peripherals: pins::ButtonPeripherals) {
             last_tx = last_tx.wrapping_add(TICKS_PER_FRAME * 2);
             dect.tx(
                 last_tx,
-                1665,
-                // FIXME: Not using a proper network ID yet
-                0x12345678,
+                const { AbsoluteChannel::new(1665).unwrap() },
+                const { NetworkId32::new(0x12345678).unwrap() },
                 // Beacon as seen by the dect_shell
                 &[17, 120, 150, 24, 112],
                 &[

--- a/hophop/src/nrfxlib_phy/mod.rs
+++ b/hophop/src/nrfxlib_phy/mod.rs
@@ -13,6 +13,8 @@ mod latency;
 mod rssi;
 mod rx;
 
+use ts_103_636_utils::identifiers::{AbsoluteChannel, NetworkId32};
+
 pub const TICKS_PER_SECOND: u64 = 69_120_000;
 pub const TICKS_PER_MILLISECOND: u64 = 69_120;
 
@@ -278,8 +280,8 @@ impl DectPhy {
     pub async fn tx(
         &mut self,
         start_time: u64,
-        channel: u16,
-        network_id: u32,
+        channel: AbsoluteChannel,
+        network_id: NetworkId32,
         pcc: &[u8],
         pdc: &[u8],
     ) -> Result<(), MixedError> {
@@ -289,18 +291,6 @@ impl DectPhy {
             _ => panic!("Not a valid header length"),
         };
 
-        // The PHY function is documented to require this, and will indeed not transmit.
-        //
-        // But expressing this in the type would be odd (the full value is computed of parts where
-        // it is not clear whose resposibility it is to not be zero) for practical deployments. (Is
-        // it really the random lower 8 bits that need to special-case if the upper 24 are all-zero?)
-        //
-        // Handling this as an error seems to be most practical, as it won't take down the whole
-        // system but will not go silently either.
-        if network_id == 0 {
-            return Err(MixedError::UsageError);
-        }
-
         unsafe {
             // FIXME: everything
             nrfxlib_sys::nrf_modem_dect_phy_tx(&nrfxlib_sys::nrf_modem_dect_phy_tx_params {
@@ -309,10 +299,10 @@ impl DectPhy {
                 // FIXME: Verify that libmodem or the network core does the >> 8 / & 0xff.
                 //
                 // (Probably: otherwise, the "must not be zero" can not be upheld).
-                network_id,
+                network_id: network_id.into(),
                 phy_type,
                 lbt_rssi_threshold_max: 0, // see below
-                carrier: channel,
+                carrier: channel.into(),
                 lbt_period: 0, // BIG FIXME
                 // The object may be smaller than expected for phy_header, but then, phy_type tells
                 // to only access the smaller struct fields anyway.

--- a/hophop/src/nrfxlib_phy/rssi.rs
+++ b/hophop/src/nrfxlib_phy/rssi.rs
@@ -9,6 +9,8 @@ use itertools::Itertools as _;
 use nrf_modem::{ErrorSource, nrfxlib_sys};
 use static_cell::StaticCell;
 
+use ts_103_636_utils::identifiers::{AbsoluteChannel, NetworkId32};
+
 use super::{DECT_EVENTS, DectEvent, DectPhy, Handle, MixedError};
 
 // Storage for RSSI results.
@@ -65,7 +67,7 @@ pub(super) unsafe fn event(rssi: *const nrfxlib_sys::nrf_modem_dect_phy_rssi_eve
         "RSSI handle {} start {} carrier {}; {} measurements",
         handle,
         rssi.meas_start_time,
-        rssi.carrier,
+        AbsoluteChannel::new(rssi.carrier).unwrap(),
         meas.len(),
     );
 
@@ -89,7 +91,7 @@ impl DectPhy {
     /// for later RSSI measurements to be taken; otherwise, later RSSI invocations will err.
     pub async fn rssi(
         &mut self,
-        carrier: u16,
+        carrier: AbsoluteChannel,
     ) -> Result<impl core::ops::Deref<Target = RssiEvent>, MixedError> {
         // Relevant DECT constant timing parameters are 1 frame = 10ms, each 10ms frame is composed
         // of 24 slots,
@@ -109,7 +111,7 @@ impl DectPhy {
         let params = nrfxlib_sys::nrf_modem_dect_phy_rssi_params {
             start_time: 0,
             handle: configured_handle.0,
-            carrier,
+            carrier: carrier.into(),
             duration: 48, // in subslots; 1 full report
             reporting_interval: nrfxlib_sys::nrf_modem_dect_phy_rssi_interval_NRF_MODEM_DECT_PHY_RSSI_INTERVAL_24_SLOTS, // 24 slots = 10ms
         };
@@ -154,8 +156,8 @@ impl DectPhy {
     /// See [`Self::rx()`] for the relevance of `network_id`.
     pub async fn rssi_bulk(
         &mut self,
-        carriers: &[u16],
-        network_id: u32,
+        carriers: &[AbsoluteChannel],
+        network_id: NetworkId32,
         mut on_event: impl AsyncFnMut(Option<Box<RssiPool>>),
         mut on_receive: impl for<'a> AsyncFnMut(super::rx::RecvResult),
     ) -> Result<(), MixedError> {
@@ -181,7 +183,7 @@ impl DectPhy {
             let params = nrfxlib_sys::nrf_modem_dect_phy_rx_params {
                 start_time: current_start_time,
                 handle: handle.0,
-                carrier: *carrier,
+                carrier: (*carrier).into(),
                 // duration: (48 * destbuffers.len()).try_into().map_err(|_| MixedError::UsageError)?, // in half slots
                 duration: u32::try_from(multiples).unwrap() * 691_200, // in time units
                 rssi_interval: nrfxlib_sys::nrf_modem_dect_phy_rssi_interval_NRF_MODEM_DECT_PHY_RSSI_INTERVAL_24_SLOTS, // 24 slots = 10ms, because we request in that granularity anyway
@@ -196,7 +198,7 @@ impl DectPhy {
                     short_network_id: 0,
                     short_rd_id: 0,
                 },
-                network_id,
+                network_id: network_id.into(),
                 rssi_level: 0,
             };
             unsafe { nrfxlib_sys::nrf_modem_dect_phy_rx(&raw const params) }.into_result()?;

--- a/hophop/src/nrfxlib_phy/rx.rs
+++ b/hophop/src/nrfxlib_phy/rx.rs
@@ -8,6 +8,8 @@ use heapless::{
 use nrf_modem::{ErrorSource, nrfxlib_sys};
 use static_cell::StaticCell;
 
+use ts_103_636_utils::identifiers::{AbsoluteChannel, NetworkId32};
+
 use super::{DECT_EVENTS, DectEvent, DectPhy, MixedError};
 
 // Packet pool.
@@ -255,18 +257,18 @@ impl DectPhy {
     ///
     /// As by the underlying design, beacons on the frequency are received immaterial of the
     /// `network_id`, but actual packets are scrambled by network ID, and can only be received from
-    /// one network.
+    /// one network. If None is given as network ID, only beacons can be received successfully.
     pub async fn rx(
         &mut self,
-        carrier: u16,
-        network_id: u32,
+        carrier: AbsoluteChannel,
+        network_id: Option<NetworkId32>,
     ) -> Result<Option<RecvResult>, MixedError> {
         unsafe {
             // FIXME: everything
             nrfxlib_sys::nrf_modem_dect_phy_rx(&nrfxlib_sys::nrf_modem_dect_phy_rx_params {
                 start_time: 0,
                 handle: 54321,
-                network_id,
+                network_id: network_id.map(u32::from).unwrap_or(0),
                 mode: nrfxlib_sys::nrf_modem_dect_phy_rx_mode_NRF_MODEM_DECT_PHY_RX_MODE_SINGLE_SHOT,
                 rssi_interval: nrfxlib_sys::nrf_modem_dect_phy_rssi_interval_NRF_MODEM_DECT_PHY_RSSI_INTERVAL_OFF,
                 link_id: nrfxlib_sys::nrf_modem_dect_phy_link_id {
@@ -274,7 +276,7 @@ impl DectPhy {
                     short_rd_id: 0,
                 },
                 rssi_level: 0,
-                carrier,
+                carrier: carrier.into(),
                 // ~ 1 second
                 duration: 70000000,
                 filter: nrfxlib_sys::nrf_modem_dect_phy_rx_filter {

--- a/ts-103-636-utils/src/identifiers.rs
+++ b/ts-103-636-utils/src/identifiers.rs
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: Copyright Christian Amsüss <chrysn@fsfe.org>, Silano Systems
+// SPDX-License-Identifier: MIT OR Apache-2.0
+//! Types for numbers commonly used in ETSI TS 103-636 "DECT-2020 New Radio (NR)".
+//!
+//! This covers types that are predominantly not backed by constants, as those would be provided in
+//! [`ts_103_636_numbers`]. (Some types still may have constants, eg. for a single "broadcast"
+//! value).
+
+use core::num::NonZero;
+
+/// A full (32-bit) Network ID.
+///
+/// Following Section 4.2.3.1 of ETSI TS 103 636-4 V2.1.1.
+///
+/// It can be split into the MSB [`NetworkId24`] and the LSB [`NetworkId8`].
+///
+/// An invariant of this type is that neither part of it is zero. Violating it may cause panics;
+/// unsoundness would only arrive from violating the more stronly enforced `NonZero` (which covers
+/// the special case of both being zero, and allows niche optimizaiton for options).
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct NetworkId32(NonZero<u32>);
+
+impl NetworkId32 {
+    const MASK_MSB: u32 = 0xffff_ff00;
+    const MASK_LSB: u32 = 0x0000_00ff;
+
+    #[must_use]
+    pub const fn new(network_id: u32) -> Option<Self> {
+        if network_id & Self::MASK_MSB == 0 || network_id & Self::MASK_LSB == 0 {
+            return None;
+        }
+
+        // At this point it is sure that this will succeed; trying to be clever about it is not
+        // worth it.
+
+        // Could be
+        //   NonZero::new(network_id).map(Self)
+        // but we have to do this until <https://github.com/rust-lang/rust/issues/143956> is
+        // stable:
+        match NonZero::new(network_id) {
+            Some(n) => Some(Self(n)),
+            None => None,
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::missing_panics_doc, reason = "using type invariant")]
+    pub const fn msb(self) -> NetworkId24 {
+        NetworkId24::new(self.0.get() >> 8).expect("own value is nonzero even there")
+    }
+
+    #[must_use]
+    #[allow(clippy::missing_panics_doc, reason = "using type invariant")]
+    pub const fn lsb(self) -> NetworkId8 {
+        #[allow(clippy::cast_possible_truncation, reason = "truncation is intended")]
+        NetworkId8::new(self.0.get() as u8).expect("own value is nonzero even there")
+    }
+}
+
+impl From<NetworkId32> for u32 {
+    fn from(value: NetworkId32) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<NetworkId32> for NonZero<u32> {
+    fn from(value: NetworkId32) -> Self {
+        value.0
+    }
+}
+
+impl core::fmt::Debug for NetworkId32 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x{:08x}", u32::from(self.0))
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for NetworkId32 {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "0x{=u32:08x}", u32::from(self.0));
+    }
+}
+
+/// The most significant part of a [`NetworkId32`], transmitted in beacons and used for scrambling
+/// non-beacon packets.
+///
+/// An invariant of this type is that it is not zero.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct NetworkId24(
+    /// This is stored in right-shifted form (i.e. of the shape 0x00NNNNN)
+    NonZero<u32>,
+);
+
+impl NetworkId24 {
+    const MASK: u32 = 0xff_ffff;
+
+    #[must_use]
+    pub const fn new(network_id: u32) -> Option<Self> {
+        if network_id & Self::MASK == 0 {
+            return None;
+        }
+
+        // At this point it is sure that this will succeed; trying to be clever about it is not
+        // worth it.
+
+        // Could be
+        //   NonZero::new(network_id).map(Self)
+        // but we have to do this until <https://github.com/rust-lang/rust/issues/143956> is
+        // stable:
+        match NonZero::new(network_id) {
+            Some(n) => Some(Self(n)),
+            None => None,
+        }
+    }
+
+    /// The ID stored in a u32 in the highest bit positions, where it would be in a full RD ID.
+    #[must_use]
+    pub fn into_high_u32(self) -> u32 {
+        u32::from(self.0) << 8
+    }
+
+    /// The ID stored in a u32 in the lower bit positions, matching its numeric value.
+    #[must_use]
+    pub fn into_low_u32(self) -> u32 {
+        u32::from(self.0) << 8
+    }
+}
+
+impl core::fmt::Debug for NetworkId24 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x{:06x}..", u32::from(self.0))
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for NetworkId24 {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "0x{=u32:06x}..", u32::from(self.0));
+    }
+}
+
+/// The least significant part of a [`NetworkId32`], transmitted in the PHY control field.
+///
+/// An invariant of this type is that it is not zero.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct NetworkId8(NonZero<u8>);
+
+impl NetworkId8 {
+    #[must_use]
+    pub const fn new(network_id: u8) -> Option<Self> {
+        // Could be
+        //   NonZero::new(network_id).map(Self)
+        // but we have to do this until <https://github.com/rust-lang/rust/issues/143956> is
+        // stable:
+        match NonZero::new(network_id) {
+            Some(n) => Some(Self(n)),
+            None => None,
+        }
+    }
+}
+
+impl From<NetworkId8> for u8 {
+    fn from(value: NetworkId8) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<NetworkId8> for NonZero<u8> {
+    fn from(value: NetworkId8) -> Self {
+        value.0
+    }
+}
+
+impl core::fmt::Debug for NetworkId8 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x…{:06x}", u8::from(self.0))
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for NetworkId8 {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "0x…{=u8:02x}", u8::from(self.0));
+    }
+}
+
+/// A Long Radio Device ID (Long RD ID).
+///
+/// Following Section 4.2.3.2 of ETSI TS 103 636-4 V2.1.1.
+///
+/// An invariant of this type is that it does not use the reserved address zero.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct LongRdId(NonZero<u32>);
+
+impl LongRdId {
+    pub const BACKEND: Self = LongRdId(NonZero::new(0xffff_fffe).unwrap());
+    pub const BROADCAST: Self = LongRdId(NonZero::new(0xffff_ffff).unwrap());
+
+    /// Loads a 32bit numeric RD ID.
+    ///
+    /// This accepts all of the regular ranges (1-0xfffffffd), the backend and the broadcast
+    /// address, but the reserved address produces None.
+    #[must_use]
+    pub const fn new(rd_id: u32) -> Option<Self> {
+        // Could be
+        //   NonZero::new(network_id).map(Self)
+        // but we have to do this until <https://github.com/rust-lang/rust/issues/143956> is
+        // stable:
+        match NonZero::new(rd_id) {
+            Some(n) => Some(Self(n)),
+            None => None,
+        }
+    }
+}
+
+impl From<LongRdId> for u32 {
+    fn from(value: LongRdId) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<LongRdId> for NonZero<u32> {
+    fn from(value: LongRdId) -> Self {
+        value.0
+    }
+}
+
+/// A Short Radio Device ID (Short RD ID).
+///
+/// Following Section 4.2.3.3 of ETSI TS 103 636-4 V2.1.1.
+///
+/// An invariant of this type is that it does not use the reserved address zero.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct ShortRdId(NonZero<u16>);
+
+impl ShortRdId {
+    pub const BROADCAST: Self = ShortRdId(NonZero::new(0xffff).unwrap());
+
+    /// Loads a 16bit numeric RD ID.
+    ///
+    /// This accepts both the regular ranges (1-0xfffe), and the broadcast address, but the
+    /// reserved address produces None.
+    #[must_use]
+    pub const fn new(rd_id: u16) -> Option<Self> {
+        // Could be
+        //   NonZero::new(network_id).map(Self)
+        // but we have to do this until <https://github.com/rust-lang/rust/issues/143956> is
+        // stable:
+        match NonZero::new(rd_id) {
+            Some(n) => Some(Self(n)),
+            None => None,
+        }
+    }
+}
+
+impl From<ShortRdId> for u16 {
+    fn from(value: ShortRdId) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<ShortRdId> for NonZero<u16> {
+    fn from(value: ShortRdId) -> Self {
+        value.0
+    }
+}

--- a/ts-103-636-utils/src/identifiers.rs
+++ b/ts-103-636-utils/src/identifiers.rs
@@ -281,6 +281,19 @@ impl From<LongRdId> for NonZero<u32> {
     }
 }
 
+impl core::fmt::Debug for LongRdId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x{:08x}", u32::from(self.0))
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for LongRdId {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "0x{=u32:08x}", u32::from(self.0));
+    }
+}
+
 /// A Short Radio Device ID (Short RD ID).
 ///
 /// Following Section 4.2.3.3 of ETSI TS 103 636-4 V2.1.1.
@@ -318,5 +331,18 @@ impl From<ShortRdId> for u16 {
 impl From<ShortRdId> for NonZero<u16> {
     fn from(value: ShortRdId) -> Self {
         value.0
+    }
+}
+
+impl core::fmt::Debug for ShortRdId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "0x{:04x}", u16::from(self.0))
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for ShortRdId {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "0x{=u16:04x}", u16::from(self.0));
     }
 }

--- a/ts-103-636-utils/src/identifiers.rs
+++ b/ts-103-636-utils/src/identifiers.rs
@@ -8,6 +8,61 @@
 
 use core::num::NonZero;
 
+/// An absolute channel number.
+///
+/// Following Section 5.4.2 of ETSI TS 103 636-2 V2.1.1
+///
+/// This type uses 13 bit (expressed in a u16).
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct AbsoluteChannel(NonZero<u16>);
+
+impl AbsoluteChannel {
+    #[must_use]
+    pub const fn new(number: u16) -> Option<Self> {
+        // Could be
+        //   NonZero::new(number).map(Self)
+        // but we have to do this until <https://github.com/rust-lang/rust/issues/143956> is
+        // stable:
+        match NonZero::new(number) {
+            Some(n) => Some(Self(n)),
+            None => None,
+        }
+    }
+}
+
+impl From<AbsoluteChannel> for u16 {
+    fn from(value: AbsoluteChannel) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<AbsoluteChannel> for NonZero<u16> {
+    fn from(value: AbsoluteChannel) -> Self {
+        value.0
+    }
+}
+
+impl core::fmt::Debug for AbsoluteChannel {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Does using a write rather than just deferring really get us rid of a :x on a surrounding
+        // struct? (It should: We use hex for identifiers but decimal for channels).
+        write!(f, "{}", self.0.get())
+    }
+}
+
+impl core::fmt::Display for AbsoluteChannel {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0.get())
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for AbsoluteChannel {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{=u16}", self.0.get());
+    }
+}
+
 /// A full (32-bit) Network ID.
 ///
 /// Following Section 4.2.3.1 of ETSI TS 103 636-4 V2.1.1.

--- a/ts-103-636-utils/src/lib.rs
+++ b/ts-103-636-utils/src/lib.rs
@@ -8,6 +8,8 @@
 pub mod mac_ie;
 pub mod mac_pdu;
 
+pub mod identifiers;
+
 /// Something in the input data structure violated this crate's expectation of what specification
 /// compliant input should look like.
 ///


### PR DESCRIPTION
This prevents hard-to-debug mixups, and makes it easier to have consistent visual representations for debugging.

The changes are *not* applied to the nrf_mac hophop module because of parallel changes there; those will be applied later. (In particular, the NI6W code is being moved around, and switching around those changes is just unreasonable at this point).