### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,29 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 -->
 # hophop
 
-*Exploring DECT-2020 NR+ in Rust.*
+*Making DECT-2020 NR+ accessible in Rust.*
 
-Stay tuned, we're getting started.
+This project provides high-level tools and applications to make ETSI TS 103 636 ("DECT-2020 New Radio (NR)", also sometimes called DECT nr+) available in Rust.
+This encompasses low-level utility libraries such as [`ts-103-636-numbers`] and [`ts-103-636-utils`],
+Rust wrappers for using either the PHY or the MAC mode of Nordic chips inside the [`hophop` crate]
+(with the intention to eventually provide unified integration for those modes and for future chips),
+and [examples] and [applications] that illustrate usage or provide early functionality.
 
-Get in touch with us through the issue tracker or by mail to [Christian Amsüss](mailto:christian@amsuess.com).
+To jump right into using it, see the [getting-started documentation].
 
-Meanwhile, have a picture of two hops:
+This project is currently active,
+and documentation may be incomplete and/or outdated.
+If you have any questions, anything is unclear or does not work, please open an issue in the issue tracker.
+
+Also, have a picture of two hops:
 
 ![Two birds, Eurasian hoopoes, sitting](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Hop_met_Jong_%2818990969281%29.jpg/960px-Hop_met_Jong_%2818990969281%29.jpg)
 
 (Picture by rob Stoeltje, [CC-BY](https://flickr.com/photos/46198971@N06/18990969281)) <!-- via Wikimedia Commons, https://commons.wikimedia.org/wiki/File:Hop_met_Jong_(18990969281).jpg -->
+
+[`ts-103-636-numbers`]: https://crates.io/crates/ts-103-636-numbers
+[`ts-103-636-utils`]: https://crates.io/crates/ts-103-636-utils
+[getting-started documentation]: ./doc/getting-started.md
+[`hophop` crate]: ./hophop/src/
+[examples]: ./examples/
+[applications]: ./applications/

--- a/applications/embedded-pt/README.md
+++ b/applications/embedded-pt/README.md
@@ -14,7 +14,7 @@ Running the application
 -----------------------
 
 * Make all the basics are set up,
-  see [the examples documentation](../../examples/README.md#for-all-examples)
+  see [getting-started documentation](../../doc/getting-started.md)
 
 * Set up an FT (fixed terminal) using the (non-phy) Nordict DECT Shell.
 

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -1,0 +1,66 @@
+<!--
+SPDX-FileCopyrightText: Copyright Christian Amsüss <chrysn@fsfe.org>, Silano Systems
+SPDX-License-Identifier: MIT OR Apache-2.0
+-->
+Getting started with hophop
+===========================
+
+Basic steps common to all examples and applications
+---------------------------------------------------
+
+* Get two (better four) [nRF9151-DK](../doc/hardware.md), connect them and turn them on.
+
+  (Wider hardware support will be added, but this is what the examples assume).
+
+* Ensure you are set up to run Ariel OS examples.
+
+  For the time being, it's easiest to follow the [Getting Started section in the Ariel OS book](https://ariel-os.github.io/ariel-os/dev/docs/book/getting-started.html).
+
+* [Ensure that you have the DECT firmware running](../doc/dect-firmware.md).
+
+* Beware that this is a research example,
+  and that depending on your location, regulation on operating these devices does apply,
+  especially as some examples emit transmissions controlled by the user alone.
+
+Examples to run
+---------------
+
+* To get the most high-level functionality, run:
+
+  - the [`embedded-pt`] application, which includes running Nordic's DECT shell as a FT (Fixed Terminal, a bit like a base station).
+
+    (By the way, there is a [glossary](./glossary.md) for terms and abbreviations).
+
+    This sets up a basic testable network connection between two devices.
+    It transports IPv6 traffic between the devices;
+    beware that this and other examples are *not yet* running proper IPv6 over DECT (as in ETSI TS 103 874-3),
+    but merely compatible with Nordic's workaround (NI6W).
+
+  - the [`bridge-pt`] application, which lets your Linux PC join into the network.
+
+    It ends with setting up an encrypted CoAP data exchange between the PC and the previous example's device.
+
+  - To see what is actually happening on the radio, you can run the RX [example].
+    Note that this only sees little useful data;
+    turn MAC layer encryption off in the DECT shell and in the examples' `main.rs` files to see more.
+    (Replace `mode: nrfxlib_sys::nrf_modem_dect_mac_security_mode_NRF_MODEM_DECT_MAC_SECURITY_MODE_1` with `…_SECURITY_MODE_NONE` in the hophop source, and reconfigure FT in the DECT shell).
+
+* The `rssi` example contains tools to visualize how much traffic there is in the DECT spectrum.
+
+[`embedded-pt`]: ../applications/embedded-pt/README.md
+[`bridge-pt`]: ../applications/bridge-pt/README.md
+[example]: ../examples/README.md
+
+Unsorted tips and tricks
+------------------------
+
+* If ever you have multiple DKs connected,
+  probe-rs will give you interactive options.
+
+  You can skip that and statically set the probe to use
+  by adding `-- --probe 1366:1059:xxxxxxxxxxxx` after the laze call (or without the `--` if you already).
+
+* Depending on the program,
+  flashing steps might complain about locked cores.
+  Until the programmer's defaults are configured more aggressively,
+  pressing the reset button shortly before the flashing step is actually executed usually helps.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,26 +5,7 @@ SPDX-License-Identifier: MIT OR Apache-2.0
 Running hophop examples
 =======================
 
-For all examples
-----------------
-
-* Get an [nRF9151-DK](../doc/hardware.md), connect it and turn it on.
-
-* Ensure you are set up to run Ariel OS examples.
-
-  For the time being, it's easiest to follow the [Getting Started section in the Ariel OS book](https://ariel-os.github.io/ariel-os/dev/docs/book/getting-started.html).
-
-* [Ensure that you have the DECT firmware running](../doc/dect-firmware.md).
-
-* Beware that this is a research example,
-  and that depending on your location, regulation on operating these devices does apply,
-  especially as some examples emit transmissions controlled by the user alone.
-
-* If ever you have multiple DKs connected,
-  probe-rs will give you interactive options.
-
-  You can skip that and statically set the probe to use
-  by adding `-- --probe 1366:1059:xxxxxxxxxxxx` after the laze call (or withtout the `--` if you already).
+For all examples, basic setup is described in [the "getting started" text](./getting-started.md).
 
 Running the RSSI example
 ------------------------


### PR DESCRIPTION
The getting-started in the examples didn't quite fit any more, and the README needed a pointer to some getting-started text anyway.