### PR TITLE
Cargo: drop patch.crates-io after nrfxlib-sys release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,7 +535,8 @@ dependencies = [
 [[package]]
 name = "nrfxlib-sys"
 version = "3.1.0+3.3.0"
-source = "git+https://github.com/chrysn-pull-requests/nrfxlib-sys?branch=nrfxlib330#6d36a4a4f9542d62cf5d9a2f20ed10103c6b35e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d024684e50e75bf8fb8d9e735b8cf5f213d615f1818825db79d6ffe6d3a12af3"
 dependencies = [
  "bindgen",
  "llvm-tools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,5 @@ repository = "https://github.com/ariel-os/hophop/"
 keywords = ["dect", "nr+"]
 categories = ["no-std::no-alloc"]
 
-[patch.crates-io]
-# from https://github.com/nrf-rs/nrfxlib-sys/pull/20
-nrfxlib-sys = { git = "https://github.com/chrysn-pull-requests/nrfxlib-sys", branch="nrfxlib330" }
-
 [workspace.metadata.release]
 sign-tag = true

--- a/applications/bridge-pt/Cargo.lock
+++ b/applications/bridge-pt/Cargo.lock
@@ -2147,7 +2147,8 @@ dependencies = [
 [[package]]
 name = "nrfxlib-sys"
 version = "3.1.0+3.3.0"
-source = "git+https://github.com/chrysn-pull-requests/nrfxlib-sys?branch=nrfxlib330#6d36a4a4f9542d62cf5d9a2f20ed10103c6b35e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d024684e50e75bf8fb8d9e735b8cf5f213d615f1818825db79d6ffe6d3a12af3"
 dependencies = [
  "bindgen",
  "llvm-tools",

--- a/applications/bridge-pt/Cargo.lock
+++ b/applications/bridge-pt/Cargo.lock
@@ -2771,7 +2771,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "slipmux"
 version = "0.4.0"
-source = "git+https://github.com/chrysn-pull-requests/slipmux?branch=decode-return-ip#b9535e6c3a632c1bf753d459ac80d519af3b4480"
+source = "git+https://github.com/teufelchen1/slipmux#9381356445f8abe92346fcd7e9ac24b1a5ddc5ac"
 dependencies = [
  "serial-line-ip",
 ]

--- a/applications/bridge-pt/Cargo.toml
+++ b/applications/bridge-pt/Cargo.toml
@@ -19,7 +19,7 @@ ts-103-636-utils = { path = "../../ts-103-636-utils/", features = ["defmt"] }
 nrf-modem = "*"
 # hophop might even want to make this a feature, but in the next iteration it'll likely just be always-on
 nrfxlib-sys = { version = "3.1.0", features = ["dect-mac"] }
-#slipmux = { version = "0.4.0", default-features = false }
-slipmux = { git = "https://github.com/chrysn-pull-requests/slipmux", branch = "decode-return-ip", default-features = false }
+# Next version after 0.4.0 has PR https://github.com/Teufelchen1/slipmux/pull/17 in
+slipmux = { git = "https://github.com/teufelchen1/slipmux", default-features = false }
 embassy-futures = "0.1.2"
 embedded-io-async = "0.6.0"

--- a/applications/bridge-pt/Cargo.toml
+++ b/applications/bridge-pt/Cargo.toml
@@ -18,12 +18,8 @@ ts-103-636-utils = { path = "../../ts-103-636-utils/", features = ["defmt"] }
 # while we're doing things hophop should do
 nrf-modem = "*"
 # hophop might even want to make this a feature, but in the next iteration it'll likely just be always-on
-nrfxlib-sys = { version = "*", features = ["dect-mac"] }
+nrfxlib-sys = { version = "3.1.0", features = ["dect-mac"] }
 #slipmux = { version = "0.4.0", default-features = false }
 slipmux = { git = "https://github.com/chrysn-pull-requests/slipmux", branch = "decode-return-ip", default-features = false }
 embassy-futures = "0.1.2"
 embedded-io-async = "0.6.0"
-
-[patch.crates-io]
-# from https://github.com/nrf-rs/nrfxlib-sys/pull/20
-nrfxlib-sys = { git = "https://github.com/chrysn-pull-requests/nrfxlib-sys", branch="nrfxlib330" }

--- a/applications/embedded-pt/Cargo.lock
+++ b/applications/embedded-pt/Cargo.lock
@@ -2303,7 +2303,8 @@ dependencies = [
 [[package]]
 name = "nrfxlib-sys"
 version = "3.1.0+3.3.0"
-source = "git+https://github.com/chrysn-pull-requests/nrfxlib-sys?branch=nrfxlib330#6d36a4a4f9542d62cf5d9a2f20ed10103c6b35e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d024684e50e75bf8fb8d9e735b8cf5f213d615f1818825db79d6ffe6d3a12af3"
 dependencies = [
  "bindgen",
  "llvm-tools",

--- a/applications/embedded-pt/Cargo.toml
+++ b/applications/embedded-pt/Cargo.toml
@@ -18,9 +18,5 @@ ts-103-636-utils = { path = "../../ts-103-636-utils/", features = ["defmt"] }
 # while we're doing things hophop should do
 nrf-modem = "*"
 # hophop might even want to make this a feature, but in the next iteration it'll likely just be always-on
-nrfxlib-sys = { version = "*", features = ["dect-mac"] }
+nrfxlib-sys = { version = "3.1.0", features = ["dect-mac"] }
 coap-handler-implementations = "0.6.2"
-
-[patch.crates-io]
-# from https://github.com/nrf-rs/nrfxlib-sys/pull/20
-nrfxlib-sys = { git = "https://github.com/chrysn-pull-requests/nrfxlib-sys", branch="nrfxlib330" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -102,7 +102,6 @@ dependencies = [
  "embassy-executor",
  "embassy-futures",
  "embassy-hal-internal",
- "embassy-net",
  "embassy-nrf",
  "embassy-stm32",
  "embassy-sync 0.7.2",
@@ -898,22 +897,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "embassy-net"
-version = "0.8.0"
-source = "git+https://github.com/ariel-os/embassy?rev=3b185bf1b3852867e4b932456600621f86f78bce#3b185bf1b3852867e4b932456600621f86f78bce"
-dependencies = [
- "document-features",
- "embassy-net-driver",
- "embassy-sync 0.7.2",
- "embassy-time",
- "embedded-io-async 0.7.0",
- "embedded-nal-async",
- "heapless 0.8.0",
- "managed",
- "smoltcp",
-]
-
-[[package]]
 name = "embassy-net-driver"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,25 +1241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2564b9f813c544241430e147d8bc454815ef9ac998878d30cc3055449f7fd4c0"
 dependencies = [
  "embedded-io 0.7.1",
-]
-
-[[package]]
-name = "embedded-nal"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56a28be191a992f28f178ec338a0bf02f63d7803244add736d026a471e6ed77"
-dependencies = [
- "nb 1.1.0",
-]
-
-[[package]]
-name = "embedded-nal-async"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5a1bd585135d302f8f6d7de329310938093da6271b37a6c94b8798795c0c6d"
-dependencies = [
- "embedded-io-async 0.7.0",
- "embedded-nal",
 ]
 
 [[package]]
@@ -2091,12 +2055,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "managed"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,7 +2140,8 @@ dependencies = [
 [[package]]
 name = "nrfxlib-sys"
 version = "3.1.0+3.3.0"
-source = "git+https://github.com/chrysn-pull-requests/nrfxlib-sys?branch=nrfxlib330#6d36a4a4f9542d62cf5d9a2f20ed10103c6b35e9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d024684e50e75bf8fb8d9e735b8cf5f213d615f1818825db79d6ffe6d3a12af3"
 dependencies = [
  "bindgen",
  "llvm-tools",
@@ -2821,19 +2780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smoltcp"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad095989c1533c1c266d9b1e8d70a1329dd3723c3edac6d03bbd67e7bf6f4bb"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "cfg-if",
- "heapless 0.8.0",
- "managed",
-]
-
-[[package]]
 name = "socket2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,6 +3307,11 @@ dependencies = [
 name = "cyw43"
 version = "0.5.0"
 source = "git+https://github.com/ariel-os/embassy?rev=603583d9#603583d94cb7ba14b3a6bbb84c8c5fea8bffea0d"
+
+[[patch.unused]]
+name = "embassy-net"
+version = "0.8.0"
+source = "git+https://github.com/ariel-os/embassy?rev=3b185bf1b3852867e4b932456600621f86f78bce#3b185bf1b3852867e4b932456600621f86f78bce"
 
 [[patch.unused]]
 name = "esp-println"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,8 +19,4 @@ ts-103-636-utils = { path = "../ts-103-636-utils/", features = ["defmt"] }
 # while we're doing things hophop should do
 nrf-modem = "*"
 # hophop might even want to make this a feature, but in the next iteration it'll likely just be always-on
-nrfxlib-sys = { version = "*", features = ["dect-mac"] }
-
-[patch.crates-io]
-# from https://github.com/nrf-rs/nrfxlib-sys/pull/20
-nrfxlib-sys = { git = "https://github.com/chrysn-pull-requests/nrfxlib-sys", branch="nrfxlib330" }
+nrfxlib-sys = { version = "3.1.0", features = ["dect-mac"] }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -7,6 +7,9 @@ version = "0.10"
 [imports.ariel]
 url = "https://raw.githubusercontent.com/ariel-os/ariel-os/main/supply-chain/audits.toml"
 
+[imports.ariel-os]
+url = "https://raw.githubusercontent.com/ariel-os/ariel-os/main/supply-chain/audits.toml"
+
 [imports.bytecode-alliance]
 url = "https://raw.githubusercontent.com/bytecodealliance/wasmtime/main/supply-chain/audits.toml"
 
@@ -17,9 +20,6 @@ url = "https://raw.githubusercontent.com/google/supply-chain/main/audits.toml"
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
 [policy.hophop]
-audit-as-crates-io = true
-
-[policy.nrfxlib-sys]
 audit-as-crates-io = true
 
 [policy.ts-103-636-numbers]
@@ -189,7 +189,7 @@ version = "0.12.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.nrfxlib-sys]]
-version = "3.1.0+3.3.0@git:6d36a4a4f9542d62cf5d9a2f20ed10103c6b35e9"
+version = "2.9.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.num_enum]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -18,6 +18,20 @@ who = "Nils Ponsard <nils.ponsard@inria.fr>"
 criteria = "safe-to-deploy"
 delta = "0.10.1 -> 0.10.2"
 
+[[audits.ariel.audits.nrfxlib-sys]]
+who = "chrysn <chrysn@fsfe.org>"
+criteria = "safe-to-deploy"
+delta = "2.9.2 -> 3.0.3+3.0.2"
+notes = "Review extends to the source of nrfxlib-sys only. The library ships also proprietary C components, which were not (and, due to being closed source, can not) be reviewed."
+
+[[audits.ariel.audits.nrfxlib-sys]]
+who = "chrysn <chrysn@fsfe.org>"
+criteria = "safe-to-deploy"
+delta = "3.0.3+3.0.2 -> 3.1.0+3.3.0"
+notes = "Review extends to the source of nrfxlib-sys only. The library ships also proprietary C components, which were not (and, due to being closed source, can not) be reviewed."
+
+[audits.ariel-os.audits]
+
 [[audits.bytecode-alliance.audits.bitflags]]
 who = "Jamey Sharp <jsharp@fastly.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Thanks Dion for merging https://github.com/nrf-rs/nrfxlib-sys/pull/20, so everything is a bit easier now.