### PR TITLE
doc: Describe FLOSS modem update process

### DIFF
--- a/doc/dect-firmware.md
+++ b/doc/dect-firmware.md
@@ -31,9 +31,12 @@ This guide assumes installation from source; ready-to-use executables are advert
 Note that we're using a fork instead of [upstream](https://github.com/circuitdojo/modem_updater)
 until [all probe-rs programmers work with it](https://github.com/circuitdojo/modem_updater/issues/4).
 
-```
+```console
 $ cargo install --git https://github.com/korken89/modem_updater.git --branch parallel-multi-probe
+[...]
 $ updater program mfw-nr+_nrf91x1_2.0.0.zip
+[2fe3:0204:0123456789ABCDEF] Programming device [========>-------------------] 265.14 KiB/801.14 KiB
+[2fe3:0204:0123456789ABCDEF]   Verification success
 ```
 
 ### Using Nordic's tools

--- a/doc/dect-firmware.md
+++ b/doc/dect-firmware.md
@@ -23,14 +23,16 @@ as per [their docs](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/n
 
 ## Flashing the firmware
 
-### Using [modem\_updater](https://github.com/circuitdojo/modem_updater)
+### Using modem\_updater
 
 *This method is recommended because it works not just with Nordic's JLink based dev kits, but with anything supported by probe-rs, and is Free Software.*
 
-This guide assumes installation from source; ready-to-use executables are advertised in the project's [repository](https://github.com/circuitdojo/modem_updater) but were not tested.
+This guide assumes installation from source; ready-to-use executables are advertised in the project's [repository](https://github.com/korken89/modem_updater) but were not tested.
+Note that we're using a fork instead of [upstream](https://github.com/circuitdojo/modem_updater)
+until [all probe-rs programmers work with it](https://github.com/circuitdojo/modem_updater/issues/4).
 
 ```
-$ cargo install --git https://github.com/circuitdojo/modem_updater.git
+$ cargo install --git https://github.com/korken89/modem_updater.git --branch parallel-multi-probe
 $ updater program mfw-nr+_nrf91x1_2.0.0.zip
 ```
 

--- a/doc/dect-firmware.md
+++ b/doc/dect-firmware.md
@@ -21,6 +21,23 @@ If that link should become unavailable,
 as per [their docs](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrfxlib/nrf_modem/doc/dectphy.html),
 "you must contact the Nordic Semiconductor sales department".
 
+## Flashing the firmware
+
+### Using [modem\_updater](https://github.com/circuitdojo/modem_updater)
+
+*This method is recommended because it works not just with Nordic's JLink based dev kits, but with anything supported by probe-rs, and is Free Software.*
+
+This guide assumes installation from source; ready-to-use executables are advertised in the project's [repository](https://github.com/circuitdojo/modem_updater) but were not tested.
+
+```
+$ cargo install --git https://github.com/circuitdojo/modem_updater.git
+$ updater program mfw-nr+_nrf91x1_2.0.0.zip
+```
+
+### Using Nordic's tools
+
+*This method is recommended for use as a fall-back, because it might cover corner cases which the other tool does not understand, or causes trouble on some platform due to missing system libraries.*
+
 Flashing this may be obvious for regular users of Nordic's tools,
 but not to those using typical Rust workflows:
 

--- a/doc/options.md
+++ b/doc/options.md
@@ -10,3 +10,4 @@ Current options:
 * Run on Ariel OS
     - Currently being established in https://github.com/ariel-os/ariel-os/pull/1562
 * embassy-net-nrf91 seems to have reverse engineerd the IPC <https://github.com/embassy-rs/embassy/blob/main/embassy-net-nrf91/src/context.rs>, and running it on the application core without any C code and running the DECT backend goes on for long enough that it becomes apparent that app and network core do talk (and eventually only fails parsing AT stuff, to no surprise as they do different AT command sets).
+  - [modem\_updater](https://github.com/circuitdojo/modem_updater) covers some aspects of IPC (firmware updates) that are not preent there.


### PR DESCRIPTION
This is incomplete because upstream is rather picky about its programmer IDs, so the path has yet to be bent to our fork, or maybe a PR.

Contributes-to: https://github.com/ariel-os/hophop/issues/49