### PR TITLE
doc, CI: Update that things work on a larger breadth of hardware

### DIFF
--- a/applications/bridge-pt/laze-project.yml
+++ b/applications/bridge-pt/laze-project.yml
@@ -4,8 +4,8 @@
 imports:
   - git:
       url: https://github.com/chrysn-pull-requests/ariel-os
-      # branch "for-hophop-20260519", which merges https://github.com/ariel-os/ariel-os/pull/2101 and https://github.com/ariel-os/ariel-os/pull/2102 and https://github.com/ariel-os/ariel-os/pull/1804
-      commit: 1993e1ea46078455da988646757cbe3c0f9eb4cc
+      # branch "for-hophop-20260519", which merges https://github.com/ariel-os/ariel-os/pull/2101 and https://github.com/ariel-os/ariel-os/pull/2102 and https://github.com/ariel-os/ariel-os/pull/1804 and https://github.com/ariel-os/ariel-os/pull/2176 -- and an extra of setting the STATE's embassy_net_driver_channel::State TX and RX count to 10
+      commit: 7af37b9d056edc3ce31249407538e76f32c0d333
     dldir: ariel-os
 
 apps:

--- a/applications/embedded-pt/laze-project.yml
+++ b/applications/embedded-pt/laze-project.yml
@@ -4,8 +4,8 @@
 imports:
   - git:
       url: https://github.com/chrysn-pull-requests/ariel-os
-      # branch "for-hophop-20260519", which merges https://github.com/ariel-os/ariel-os/pull/2101 and https://github.com/ariel-os/ariel-os/pull/2102 and https://github.com/ariel-os/ariel-os/pull/1804 -- and an extra of setting the STATE's embassy_net_driver_channel::State TX and RX count to 10
-      commit: 3c1cb06eccfe9063280ec163db3263822718fd08
+      # branch "for-hophop-20260519", which merges https://github.com/ariel-os/ariel-os/pull/2101 and https://github.com/ariel-os/ariel-os/pull/2102 and https://github.com/ariel-os/ariel-os/pull/1804 and https://github.com/ariel-os/ariel-os/pull/2176 -- and an extra of setting the STATE's embassy_net_driver_channel::State TX and RX count to 10
+      commit: 7af37b9d056edc3ce31249407538e76f32c0d333
     dldir: ariel-os
 
 apps:

--- a/doc/hardware.md
+++ b/doc/hardware.md
@@ -9,13 +9,13 @@ with the expectation to support all nRF9120 based ones
 (which are nRF9151 and nRF9131;
 note that the nRF916x series, while using identical radio firmware, contains different components).
 
-The typical development board for which initial applications are laid out
-is the [nRF9151-DK](https://www.nordicsemi.com/Products/Development-hardware/nRF9151-DK),
-whose built-in antenna is suitable for basic DECT operation.
+Supported boards are (names in parentheses are the Ariel OS target names):
 
-When experimenting with the nRF9131 through the [nRF9131-EK](https://docs.nordicsemi.com/bundle/ncs-latest/page/zephyr/boards/nordic/nrf9131ek/doc/index.html),
-or any other untested board,
-beware that it may not be trivial to obtain antennas for the DECT-2020 NR+ bands.
+* [nRF9151-DK](https://www.nordicsemi.com/Products/Development-hardware/nRF9151-DK) ([`nrf9151-dk`](https://ariel-os.github.io/ariel-os/dev/docs/book/boards/nrf9151-dk.html)), including the SMA variant
+* [makerdiary nRF9151 Connect Kit](https://makerdiary.com/products/nrf9151-connectkit) ([`makerdiary-nrf9151-connect-kit`](https://ariel-os.github.io/ariel-os/dev/docs/book/boards/makerdiary-nrf9151-connect-kit.html))
+* [Thingy:91 X](https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-91-X) ([`nordic-thingy-91-x-nrf9151`](https://ariel-os.github.io/ariel-os/dev/docs/book/boards/nordic-thingy-91-x.html), using the default firmware on the nRF5340)
+
+Examples are usually given for the `nrf9151-dk`; that target name (`-b` argument) needs to be adjusted depending on your hardware, but should then run everywhere.
 
 Note that the devices as shipped are running an LTE firmware on their network core;
 see [the DECT firmware page](./dect-firmware.md) on how to change that.

--- a/examples/laze-project.yml
+++ b/examples/laze-project.yml
@@ -4,8 +4,8 @@
 imports:
   - git:
       url: https://github.com/chrysn-pull-requests/ariel-os
-      # branch "for-hophop-20260519", which merges https://github.com/ariel-os/ariel-os/pull/2101 and https://github.com/ariel-os/ariel-os/pull/2102 and https://github.com/ariel-os/ariel-os/pull/1804
-      commit: 1993e1ea46078455da988646757cbe3c0f9eb4cc
+      # branch "for-hophop-20260519", which merges https://github.com/ariel-os/ariel-os/pull/2101 and https://github.com/ariel-os/ariel-os/pull/2102 and https://github.com/ariel-os/ariel-os/pull/1804 and https://github.com/ariel-os/ariel-os/pull/2176 -- and an extra of setting the STATE's embassy_net_driver_channel::State TX and RX count to 10
+      commit: 7af37b9d056edc3ce31249407538e76f32c0d333
     dldir: ariel-os
 
 apps:

--- a/test.sh
+++ b/test.sh
@@ -31,6 +31,12 @@ done
 # Initially those do build tests only; turning clippy and checks on is a good
 # next step, but only once these stabilize a little.
 
+# Listing them all so we notice if any fail. (There can be differences in
+# build-time issues like "do we have a case for that UART configuration", but
+# also laze-time requirements like "this needs an LED", and I'd rather exclude
+# them explicitly here then to make sure this matches the docs).
+BOARDS="-b nrf9151-dk -b makerdiary-nrf9151-connect-kit -b nordic-thingy-91-x-nrf9151"
+
 cd examples
 # We enable IPv6, and current Ariel needs something in there
 export CONFIG_NET_IPV6_STATIC_ADDRESS=fe80::1
@@ -38,12 +44,12 @@ export CONFIG_NET_IPV6_STATIC_GATEWAY_ADDRESS=::
 # FIXME: Going through `run` but not really -- because a plain build fails due to the multiple binaries.
 for EX in rx tx rssi ping
 do
-    laze build -b nrf9151-dk -D LOG=trace -D CARGO_RUNNER=true run --bin ${EX}
+    laze build ${BOARDS} -D LOG=trace -D CARGO_RUNNER=true --multiple-tasks run --bin ${EX}
 done
 cd ..
 
 cd applications
 for APP in embedded-pt bridge-pt
 do
-    laze build -C $APP/ -b nrf9151-dk -D LOG=trace
+    laze build -C $APP/ ${BOARDS} -D LOG=trace
 done


### PR DESCRIPTION
Thingy 91 X works out of the box; for the makerdiary board, this PR has to wait until we're run an updated Ariel where board support is in (or just update it in this PR).

CI should probably also run if not build tests then at least cargo checks.

Closes: https://github.com/ariel-os/hophop/issues/49